### PR TITLE
Automate Sphinx-based documentation deployment

### DIFF
--- a/.github/workflows/sphinx-docs.yml
+++ b/.github/workflows/sphinx-docs.yml
@@ -27,6 +27,7 @@ jobs:
           retention-days: 90
   
   deploy-docs:
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     needs: build-docs
     
     permissions:
@@ -45,6 +46,5 @@ jobs:
     steps:
      - name: Deploy artifact to GitHub Pages
        id: deployment
-       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
        uses: actions/deploy-pages@v1
          

--- a/.github/workflows/sphinx-docs.yml
+++ b/.github/workflows/sphinx-docs.yml
@@ -1,0 +1,45 @@
+name: Docs
+on: [push, pull_request, workflow_dispatch]
+
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: Install dependencies
+        run: |
+          pip install sphinx sphinx_rtd_theme
+      - name: Sphinx build
+        run: |
+          sphinx-build docs/source docs/_build
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v1
+        
+        with:
+          path: docs/_build
+          retention-days: 90
+  
+  deploy-docs:
+    needs: build-docs
+    
+    permissions:
+      pages: write
+      id-token: write
+    
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.output.page_url }}
+      
+    concurrency: 
+      group: "pages"
+      cancel-in-progress: true
+    
+    runs-on: ubuntu-latest
+    steps:
+     - name: Deploy artifact to GitHub Pages
+       id: deployment
+       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+       uses: actions/deploy-pages@v1
+         

--- a/.github/workflows/sphinx-docs.yml
+++ b/.github/workflows/sphinx-docs.yml
@@ -6,8 +6,8 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
       - name: Install dependencies
         run: |
           pip install sphinx sphinx_rtd_theme

--- a/.github/workflows/sphinx-docs.yml
+++ b/.github/workflows/sphinx-docs.yml
@@ -1,5 +1,10 @@
 name: Docs
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+  workflow_dispatch:
 
 
 jobs:


### PR DESCRIPTION
This Action will run automatically on push/PR or if manually run.

If done via push, this will deploy the built Sphinx docs onto the GitHub Pages at http://cbica.github.io/MRISnapshot automatically.

I am working out how to best do this so as to keep track of docs for multiple versions.
(Generally, it is best to keep an archive of old docs in order so that users who *need* older versions for some reason have docs available to them). 
However, this only is needed if the API or CLI usage changes often. 